### PR TITLE
Run work as local futures to avoid need for Send + Sync

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ prost = "0.6"
 serde = "1.0"
 serde_json = "1.0"
 tonic = { version = "0.3", features = ["tls", "transport"] }
-tokio = { version = "0.2", features = ["fs", "time", "stream"] }
+tokio = { version = "0.2", features = ["fs", "time", "stream", "rt-util"] }
 thiserror = "1.0"
 tracing = "0.1"
 tracing-futures = "0.2"


### PR DESCRIPTION
This allows handler functions to return local futures which is convenient in some cases.